### PR TITLE
Added support for query middleware (findOneAndUpdate, update)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "8"
 before_install:
  - npm install mocha -g
 services:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ personSchema.plugin(autoref, [
 var Person = mongoose.model('Person', personSchema);
 ```
 
+The autoref behaviour is implemented using mongoose's post middlewares for `save`, `findOneAndUpdate` and `update`.
+For example, here are two ways of saving a `Person` document:
+
+```
+var autoref = require('mongoose-autorefs');
+
+var person = new Person({name: 'Mike'});
+person.save(function(err, mike){
+    // When you get here, autoref has also completed.
+    // Do some stuff
+});
+
+Person.findByIdAndUpdate(person._id, person, { upsert: true, setDefaultsOnInsert: true, new: true }).exec(function(err, mike){
+    // When you get here, autoref has also completed.
+    // Do some stuff
+});
+```
+
 mongoose-autorefs uses another npm package [mongoose-populator](https://www.npmjs.com/package/mongoose-populator) to fully populate documents in the autoref hierarchy.
 
 **The `options` array**
@@ -51,28 +69,8 @@ In the above example, when saving a `Company` document with an `employee`, autor
 This will also work for arrays and arbitrarily nested documents.
 
 
-**IMPORTANT NOTES**
+**IMPORTANT NOTE**
 
-**1.**  The autoref behaviour is implemented using mongoose's post save middleware. This means the autoref functionality **will only execute on a `save`**. The various `findAndModify` methods **do not** fire the post save middleware.
-
-**2.**  Internally, autoref saves the refs using findOneAndUpdate, so autorefs do not cascade updates. If you want to save the same reference to multiple places, provide a path for each in your plugin config.
-
-**3.**  Since the post save middleware currently does not include a `next` or `done` callback, you can only determine when autoref has completed by listening to the 'autoref' event on the document after you save.
-The event passes the updated document, or the original document if the autoref failed.
-For example, saving a `Person` document and listening for the complete event:
-
-```
-var autoref = require('mongoose-autorefs');
-
-var person = new Person({name: 'Mike'});
-person.save(function(err, mike){
-    // Listen for the autoref completed event
-    personn.on('autoref', function(err, mike){
-        // Do some stuff
-    });
-});
-```
-
-The complete event returns any errors, along with the original document the event was fired on. The document will be returned regardless of any errors during the autoref phase.
+Internally, autoref saves the refs using findOneAndUpdate, so autorefs do not cascade updates. If you want to save the same reference to multiple places, provide a path for each in your plugin config.
 
 =======

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ module.exports = function (schema, options){
           return next();
         }
 
-        autorefs(doc._id, doc, function(finishedDoc, err){
-            finishedDoc.emit('autoref', err, finishedDoc);
+        autorefs(doc._id, doc, function(err){
             if (err) {
               return next(err);
             }
@@ -29,8 +28,7 @@ module.exports = function (schema, options){
           return next();
         }
 
-        autorefs(doc._id, doc, function(finishedDoc, err){
-            finishedDoc.emit('autoref', err, finishedDoc);
+        autorefs(doc._id, doc, function(err){
             if (err) {
               return next(err);
             }
@@ -44,8 +42,7 @@ module.exports = function (schema, options){
           return next();
         }
 
-        autorefs(doc._id, doc, function(finishedDoc, err){
-            finishedDoc.emit('autoref', err, finishedDoc);
+        autorefs(doc._id, doc, function(err){
             if (err) {
               return next(err);
             }
@@ -59,7 +56,7 @@ module.exports = function (schema, options){
         function finish(err){
             --saves;
             if (saves === 0) {
-                return callback(originalDoc, err);
+                return callback(err);
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -8,15 +8,58 @@ module.exports = function (schema, options){
     if (!Array.isArray(options)) return console.error('Non-array found in autoref options for schema ' + schema.name);
     if (options.length === 0) return console.error('No autoref options provided for schema ' + schema.name);
 
-    schema.post('save', function(){
-        var refId = this._id;
-        var originalDoc = this;
+    schema.post('save', function(doc, next){
+        // making sure the doc is a valid mongoose doc, with the function we need
+        if (!doc.populate) {
+          return next();
+        }
+
+        autorefs(doc._id, doc, function(finishedDoc, err){
+            finishedDoc.emit('autoref', err, finishedDoc);
+            if (err) {
+              return next(err);
+            }
+            return next();
+        });
+    });
+
+    schema.post('findOneAndUpdate', function(doc, next){
+        // making sure the doc is a valid mongoose doc, with the function we need
+        if (!doc.populate) {
+          return next();
+        }
+
+        autorefs(doc._id, doc, function(finishedDoc, err){
+            finishedDoc.emit('autoref', err, finishedDoc);
+            if (err) {
+              return next(err);
+            }
+            return next();
+        });
+    });
+
+    schema.post('update', function(doc, next){
+        // making sure the doc is a valid mongoose doc, with the function we need
+        if (!doc.populate) {
+          return next();
+        }
+
+        autorefs(doc._id, doc, function(finishedDoc, err){
+            finishedDoc.emit('autoref', err, finishedDoc);
+            if (err) {
+              return next(err);
+            }
+            return next();
+        });
+    });
+
+    function autorefs(refId, originalDoc, callback){
         var saves = options.length;
 
         function finish(err){
             --saves;
             if (saves === 0) {
-                return originalDoc.emit('autoref', err, originalDoc);
+                return callback(originalDoc, err);
             }
         }
 
@@ -87,5 +130,5 @@ module.exports = function (schema, options){
                 });
             });
         });
-    });
+    };
 };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * Created by Simon on 10/12/2014.
  */
 
+var mongoose = require('mongoose');
 var populate = require('mongoose-populator');
 
 module.exports = function (schema, options){
@@ -25,7 +26,17 @@ module.exports = function (schema, options){
     schema.post('findOneAndUpdate', function(doc, next){
         // making sure the doc is a valid mongoose doc, with the function we need
         if (!doc.populate) {
-          return next();
+            if (this.schema && this.model && this.model.modelName) {
+                var model = mongoose.model(this.model.modelName, this.schema);
+                doc = new model(doc);
+
+                if (!doc.populate) {
+                    return next();
+                }
+            }
+            else {
+                return next();
+            }
         }
 
         autorefs(doc._id, doc, function(err){
@@ -39,7 +50,17 @@ module.exports = function (schema, options){
     schema.post('update', function(doc, next){
         // making sure the doc is a valid mongoose doc, with the function we need
         if (!doc.populate) {
-          return next();
+            if (this.schema && this.model && this.model.modelName) {
+                var model = mongoose.model(this.model.modelName, this.schema);
+                doc = new model(doc);
+
+                if (!doc.populate) {
+                    return next();
+                }
+            }
+            else {
+                return next();
+            }
         }
 
         autorefs(doc._id, doc, function(err){

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Simon Trewhella",
   "license": "MIT",
   "dependencies": {
-    "mongoose": "^3.8.20",
+    "mongoose": "^4.6.0",
     "mongoose-populator": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/strewhella/mongoose-autorefs/issues",
   "main": "index.js",
   "scripts": {
-    "test": "mocha -R spec ./test/test.js"
+    "test": "mocha --exit -R spec ./test/test.js"
   },
   "keywords": [
     "mongoose",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-autorefs",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "Mongoose plugin for automatic updating of referenced documents",
   "repository": "https://github.com/strewhella/mongoose-autorefs.git",
   "bugs": "https://github.com/strewhella/mongoose-autorefs/issues",

--- a/test/test.js
+++ b/test/test.js
@@ -17,13 +17,11 @@ describe('1-1 self referencing relationship', function(){
                     m.partner = l._id;
                     m.save(function(err, m) {
                         error = err;
-                        m.on('autoref', function() {
-                            db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                mike = m;
-                                db.Person.findOne({name: 'Lisa'}, function (err, l) {
-                                    lisa = l;
-                                    done();
-                                });
+                        db.Person.findOne({name: 'Mike'}, function (err, m) {
+                            mike = m;
+                            db.Person.findOne({name: 'Lisa'}, function (err, l) {
+                                lisa = l;
+                                done();
                             });
                         });
                     });
@@ -56,15 +54,13 @@ describe('many-many self referencing relationship', function() {
                         m.friends = [l._id, g._id];
                         m.save(function (err, m) {
                             error = err;
-                            m.on('autoref', function() {
-                                db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                    mike = m;
-                                    db.Person.findOne({name: 'Lisa'}, function (err, l) {
-                                        lisa = l;
-                                        db.Person.findOne({name: 'Greg'}, function (err, g) {
-                                            greg = g;
-                                            done();
-                                        });
+                            db.Person.findOne({name: 'Mike'}, function (err, m) {
+                                mike = m;
+                                db.Person.findOne({name: 'Lisa'}, function (err, l) {
+                                    lisa = l;
+                                    db.Person.findOne({name: 'Greg'}, function (err, g) {
+                                        greg = g;
+                                        done();
                                     });
                                 });
                             });
@@ -108,13 +104,11 @@ describe('1-many relationship', function() {
                     m.employer = s._id;
                     m.save(function (err, m) {
                         error = err;
-                        m.on('autoref', function() {
-                            db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                mike = m;
-                                db.Company.findById(s._id, function (err, s) {
-                                    sweet = s;
-                                    done();
-                                });
+                        db.Person.findOne({name: 'Mike'}, function (err, m) {
+                            mike = m;
+                            db.Company.findById(s._id, function (err, s) {
+                                sweet = s;
+                                done();
                             });
                         });
                     });
@@ -149,13 +143,11 @@ describe('many-1 relationship', function() {
                     s.employees = [m._id];
                     s.save(function (err, s) {
                         error = err;
-                        s.on('autoref', function() {
-                            db.Company.findOne({name: 'Sweet'}, function (err, s) {
-                                sweet = s;
-                                db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                    mike = m;
-                                    done();
-                                });
+                        db.Company.findOne({name: 'Sweet'}, function (err, s) {
+                            sweet = s;
+                            db.Person.findOne({name: 'Mike'}, function (err, m) {
+                                mike = m;
+                                done();
                             });
                         });
                     });
@@ -191,16 +183,14 @@ describe('many-many relationship company to person', function() {
                         s.interviewees = [m._id, l._id];
                         s.save(function(err, s) {
                             error = err;
-                            s.on('autoref', function() {
-                                db.Company.findOne({name: 'Sweet'}, function (err, s) {
-                                    sweet = s;
-                                    db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                        mike = m;
-                                        db.Person.findOne({name: 'Lisa'}, function (err, l) {
-                                            lisa = l;
-                                            done();
-                                        })
-                                    });
+                            db.Company.findOne({name: 'Sweet'}, function (err, s) {
+                                sweet = s;
+                                db.Person.findOne({name: 'Mike'}, function (err, m) {
+                                    mike = m;
+                                    db.Person.findOne({name: 'Lisa'}, function (err, l) {
+                                        lisa = l;
+                                        done();
+                                    })
                                 });
                             });
                         });
@@ -244,15 +234,13 @@ describe('many-many relationship person to company', function() {
                         m.interviewers = [s._id, sch._id];
                         m.save(function(err, ma){
                             error = err;
-                            ma.on('autoref', function() {
-                                db.Person.findOne({name: 'Mike'}, function (err, m) {
-                                    mike = m;
-                                    db.Company.findOne({name: 'Sweet'}, function (err, s) {
-                                        db.Company.findOne({name: 'Schmick'}, function (err, sch) {
-                                            sweet = s;
-                                            schmick = sch;
-                                            done();
-                                        });
+                            db.Person.findOne({name: 'Mike'}, function (err, m) {
+                                mike = m;
+                                db.Company.findOne({name: 'Sweet'}, function (err, s) {
+                                    db.Company.findOne({name: 'Schmick'}, function (err, sch) {
+                                        sweet = s;
+                                        schmick = sch;
+                                        done();
                                     });
                                 });
                             });
@@ -296,21 +284,15 @@ describe('1-many relationship no duplicates on multiple save', function() {
                     m.employer = s._id;
                     m.save(function (err, m) {
                         error = err;
-                        m.on('autoref', function() {
-                            // Do not subscribe to autoref more than one on the same instance
-                            m.removeAllListeners('autoref');
-                            process.nextTick(function() {
-                                m.name = 'Mike2';
-                                m.save(function (err, m) {
-                                    error = err;
-                                    m.on('autoref', function() {
-                                        db.Person.findOne({name: 'Mike2'}, function (err, m) {
-                                            mike = m;
-                                            db.Company.findById(s._id, function (err, s) {
-                                                sweet = s;
-                                                done();
-                                            });
-                                        });
+                        process.nextTick(function() {
+                            m.name = 'Mike2';
+                            m.save(function (err, m) {
+                                error = err;
+                                db.Person.findOne({name: 'Mike2'}, function (err, m) {
+                                    mike = m;
+                                    db.Company.findById(s._id, function (err, s) {
+                                        sweet = s;
+                                        done();
                                     });
                                 });
                             });
@@ -365,12 +347,10 @@ describe('bad input', function() {
                 person: mike._id
             });
 
-            bad.save(function(){
-                bad.on('autoref', function(err, bad){
-                    should.not.exist(err);
-                    should.exist(bad);
-                    done();
-                });
+            bad.save(function(err, bad){
+                should.not.exist(err);
+                should.exist(bad);
+                done();
             });
         });
     });
@@ -390,12 +370,10 @@ describe('bad input', function() {
                 person: mike._id
             });
 
-            bad.save(function(){
-                bad.on('autoref', function(err, bad){
-                    should.not.exist(err);
-                    should.exist(bad);
-                    done();
-                });
+            bad.save(function(err, bad){
+                should.not.exist(err);
+                should.exist(bad);
+                done();
             });
         });
     });
@@ -482,12 +460,10 @@ describe('when populating deeply nested objects', function() {
             Two.findOne({data:'two-two'}, function(err, twoTwo){
                 oneOne.two = twoTwo._id;
                 oneOne.save(function(err, oneOne){
-                    oneOne.on('autoref', function(err, oneOne){
-                        oneOne.two.data.should.eql('two-two');
-                        oneOne.two.threes[0].data.should.eql('three-two');
-                        oneOne.two.threes[0].four.data.should.eql('four-two');
-                        done();
-                    });
+                    oneOne.two.data.should.eql('two-two');
+                    oneOne.two.threes[0].data.should.eql('three-two');
+                    oneOne.two.threes[0].four.data.should.eql('four-two');
+                    done();
                 });
             });
         });

--- a/test/testdb.js
+++ b/test/testdb.js
@@ -60,15 +60,9 @@ module.exports.init = function(done) {
         var lisa = new Person({_id: mongoose.Types.ObjectId(), name: 'Lisa'});
 
         greg.save(function (err, greg) {
-            greg.on('autoref', function(err, greg) {
-                mike.save(function (err, mike) {
-                    mike.on('autoref', function(err, mike){
-                        lisa.save(function (err, lisa) {
-                            lisa.on('autoref', function(err, lisa) {
-                                createCompanies(greg, mike, lisa);
-                            });
-                        });
-                    });
+            mike.save(function (err, mike) {
+                lisa.save(function (err, lisa) {
+                    createCompanies(greg, mike, lisa);
                 });
             });
         });
@@ -78,13 +72,9 @@ module.exports.init = function(done) {
             var schmick = new Company({_id:mongoose.Types.ObjectId(), name: 'Schmick'});
 
 
-            sweet.save(function(){
-                sweet.on('autoref', function(err, sweet) {
-                    schmick.save(function () {
-                        schmick.on('autoref', function(err, schmick) {
-                            done(db);
-                        });
-                    });
+            sweet.save(function(err, sweet){
+                schmick.save(function (err, schmick) {
+                    done(db);
                 });
             })
         }


### PR DESCRIPTION
This will make the plugin work with findOneAndUpdate/findByIdAndUpdate and update queries.
In order for it to work, the query must return a valid mongoose document, so lean() cannot be used on those queries.
I have added a check to make sure the populate function exists on the returned doc (which it won't when using lean()).
In order to get the same effect as lean(), just do a .toObject() on the resulting data instead.
