### PR TITLE
fixed depricated

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ module.exports = function (schema, options){
                         update[operation] = {};
                         update[operation][dest] = refId;
 
-                        doc.constructor.update({ _id: doc._id }, update, function(err){
+                        doc.constructor.updateOne({ _id: doc._id }, update, function(err){
                             if (err){
                                 return finish(new Error('Error saving autoref: ' + err.message + ' (doc ' + doc._id + ')' + update), originalDoc);
                             }


### PR DESCRIPTION
Fix for this error
mongoose: ^v.5
(node:22828) DeprecationWarning: collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.
(node:22828) UnhandledPromiseRejectionWarning: Error: Error saving autoref: modelForCurrentDoc.schema._getVirtual is not a function (doc 15)[object Object]